### PR TITLE
Feature/allow specifying custom splunkjsonformatter

### DIFF
--- a/src/Serilog.Sinks.Splunk.Durable/Serilog.Sinks.Splunk.Durable.csproj
+++ b/src/Serilog.Sinks.Splunk.Durable/Serilog.Sinks.Splunk.Durable.csproj
@@ -24,7 +24,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company />
     <PackageId>Serilog.Sinks.Splunk.Durable</PackageId>
-    <PackageVersion>1.1</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Serilog.Sinks.Splunk.Durable/Sinks/Splunk/Durable/EventCollectorSink.cs
+++ b/src/Serilog.Sinks.Splunk.Durable/Sinks/Splunk/Durable/EventCollectorSink.cs
@@ -19,6 +19,7 @@ using System.Net.Http;
 using System.Text;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks.Splunk.Durable
 {
@@ -37,10 +38,12 @@ namespace Serilog.Sinks.Splunk.Durable
             long? bufferSizeLimitBytes,
             long? eventBodyLimitBytes,
             HttpMessageHandler messageHandler,
-            long? retainedInvalidPayloadsLimitBytes)
+            long? retainedInvalidPayloadsLimitBytes,
+            ITextFormatter jsonFormatter = null)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
+            if (jsonFormatter == null) jsonFormatter = new CompactSplunkJsonFormatter(renderTemplate: true);
 
             var fileSet = new FileSet(bufferBaseFilename);
 
@@ -58,7 +61,7 @@ namespace Serilog.Sinks.Splunk.Durable
             const long individualFileSizeLimitBytes = 100L * 1024 * 1024;
             _sink = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
-                .WriteTo.File(new CompactSplunkJsonFormatter(renderTemplate: true),
+                .WriteTo.File(jsonFormatter,
                         fileSet.RollingFilePathFormat,
                         rollingInterval: RollingInterval.Day,
                         fileSizeLimitBytes: individualFileSizeLimitBytes,

--- a/src/Serilog.Sinks.Splunk.Durable/SplunkLoggingConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Splunk.Durable/SplunkLoggingConfigurationExtensions.cs
@@ -19,6 +19,7 @@ using Serilog.Events;
 using System.Net.Http;
 using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Splunk.Durable;
+using Serilog.Formatting;
 
 namespace Serilog
 {
@@ -42,6 +43,7 @@ namespace Serilog
         /// <param name="retainedInvalidPayloadsLimitBytes"></param>
         /// <param name="messageHandler"></param>
         /// <param name="levelSwitch"></param>
+        /// <param name="jsonFormatter">The text formatter used to render log events into a JSON format for consumption by Splunk</param>
         /// <returns></returns>
         public static LoggerConfiguration SplunkEventCollector(
            this LoggerSinkConfiguration configuration,
@@ -55,7 +57,8 @@ namespace Serilog
            long? eventBodyLimitBytes = 512 * 1024,
            long? retainedInvalidPayloadsLimitBytes = null,
            HttpMessageHandler messageHandler = null,
-           LoggingLevelSwitch levelSwitch = null)
+           LoggingLevelSwitch levelSwitch = null,
+           ITextFormatter jsonFormatter = null)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
@@ -68,7 +71,8 @@ namespace Serilog
                 bufferSizeLimitBytes,
                 eventBodyLimitBytes,
                 messageHandler,
-                retainedInvalidPayloadsLimitBytes);
+                retainedInvalidPayloadsLimitBytes,
+                jsonFormatter);
 
             return configuration.Sink(eventCollectorSink, restrictedToMinimumLevel, levelSwitch);
         }

--- a/test/Serilog.Sinks.Splunk.Durable.Tests/Serilog.Sinks.Splunk.Durable.Tests.csproj
+++ b/test/Serilog.Sinks.Splunk.Durable.Tests/Serilog.Sinks.Splunk.Durable.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net47;netcoreapp3.1</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>

--- a/test/Serilog.Sinks.Splunk.Durable.Tests/Serilog.Sinks.Splunk.Durable.Tests.csproj
+++ b/test/Serilog.Sinks.Splunk.Durable.Tests/Serilog.Sinks.Splunk.Durable.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net47;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net47;netcoreapp3.1</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
Hi there 👋 .

I found your NuGet package when looking for a package that was better at coping with Splunk server-side failures, and stumbled upon your durable version of the Splunk sink for Serilog. Thanks for making it!

When test-driving the NuGet package I found that the fields ended up with different names in Splunk. For instance, @level instead of Level, and no Properties.* before custom properties. 

The solution for me would be to specify a custom `ITextFormatter`, so that I can take care of serialization myself (or lift the formatter from the `Serilog.Sinks.Splunk` package).

This PR allows for that extension. I opted to leave the custom formatter out, since people can find it freely on [Serilog.Sinks.Splunk](https://github.com/serilog-contrib/serilog-sinks-splunk/blob/dev/src/Serilog.Sinks.Splunk/Sinks/Splunk/SplunkJsonFormatter.cs).